### PR TITLE
add missing ref to sha

### DIFF
--- a/.github/workflows/attest-build-provenance-slsa3-rw.yml
+++ b/.github/workflows/attest-build-provenance-slsa3-rw.yml
@@ -127,6 +127,9 @@ jobs:
         run: echo "self-hosted runner detected, failing job!" && exit 1
       - name: checkout-source-repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
       - name: slsa-build
         if: ${{ runner.environment == 'github-hosted' }}
         uses: ./.github/actions/slsa-build


### PR DESCRIPTION
- https://github.com/ramonpetgrave/github-build-attestations-rw/blob/main/docs/architecture.md#toctou-checkout-by-sha
- https://github.com/ramonpetgrave/github-build-attestations-rw/blob/b1c7c74196203b0d455b55a61ac51e4f0c9afa1a/.github/workflows/stub-workflow-do-not-trust.yml#L64-L68